### PR TITLE
manifests: add initial manifests with a collector deployment

### DIFF
--- a/configmap.yaml
+++ b/configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: collector-config
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+    processors:
+      resourcedetection:
+        detectors: [gcp]
+        timeout: 10s
+    exporters:
+      logging:
+      googlecloud:
+      googlemanagedprometheus:
+    service:
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [resourcedetection]
+          exporters: [googlecloud]
+        traces:
+          receivers: [otlp]
+          processors: [resourcedetection]
+          exporters: [googlecloud]
+        metrics:
+          receivers: [otlp]
+          processors: [resourcedetection]
+          exporters: [googlemanagedprometheus]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opentelemetry-collector
+  labels:
+    app: opentelemetry-collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: opentelemetry-collector
+  template:
+    metadata:
+      labels:
+        app: opentelemetry-collector
+    spec:
+      containers:
+      - name: opentelemetry-collector
+        imagePullPolicy: Always
+        image: otel/opentelemetry-collector-contrib:0.99.0
+        command:
+          - "/otelcol-contrib"
+          - "--config=/conf/collector.yaml"
+        ports:
+          - containerPort: 4317
+        volumeMounts:
+          - name: collector-config
+            mountPath: /conf
+      volumes:
+          - name: collector-config
+            configMap:
+              name: collector-config
+              items:
+              - key: collector.yaml
+                path: collector.yaml

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry-collector
+spec:
+  type: ClusterIP
+  selector:
+    app: opentelemetry-collector
+  ports:
+    - name: otel-grpc
+      protocol: TCP
+      port: 4317
+      targetPort: 4317


### PR DESCRIPTION
This change adds the bare mionimum deploymnet manifests to get telemetry into cloud observability. There are still a few things missing that will be added in follow up PRs, specifically: the RBAC and service account settings and a full collector config including the `k8sattributesprocessor`.