### PR TITLE
cloudbuild: add integration test that checks that the collector installs

### DIFF
--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -1,0 +1,73 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# set the project ID in the k8s manifest for service account/workload identity
+- name: 'ubuntu'
+  id: Replace
+  script: |
+    #!/usr/bin/env bash
+    sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" collector/*
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+
+# deploy the manifests in GKE
+- name: 'gcr.io/cloud-builders/kubectl'
+  id: Deploy
+  args:
+  - 'apply'
+  - '-f'
+  - './collector/.'
+  env:
+  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+
+# assert that all pods are up and running
+- name: 'gcr.io/cloud-builders/kubectl'
+  id: AssertReady
+  args:
+  - 'wait'
+  - '--for=condition=Ready'
+  - '--timeout=300s'
+  - '-n'
+  - 'opentelemetry'
+  - 'pods'
+  - '--all'
+  env:
+  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+
+# delete everything in the opentelemetry namespace
+- name: 'gcr.io/cloud-builders/kubectl'
+  id: TearDown
+  args:
+  - 'delete'
+  - 'all'
+  - '--all'
+  - '-n'
+  - 'opentelemetry'
+  env:
+  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+
+# delete the opentelemetry namespace
+- name: 'gcr.io/cloud-builders/kubectl'
+  id: DeleteNamespace
+  args:
+  - 'delete'
+  - 'namespace'
+  - 'opentelemetry'
+  env:
+  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -22,6 +22,16 @@ steps:
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 
+# create a GKE cluster
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: CreateCluster
+  args:
+  - 'container'
+  - 'clusters'
+  - 'create'
+  - '${COMMIT_SHA}'
+  - '--zone=${LOCATION}'
+
 # deploy the manifests in GKE
 - name: 'gcr.io/cloud-builders/kubectl'
   id: Deploy
@@ -31,7 +41,7 @@ steps:
   - './collector/.'
   env:
   - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${COMMIT_SHA}'
 
 # assert that all pods are up and running
 - name: 'gcr.io/cloud-builders/kubectl'
@@ -46,28 +56,15 @@ steps:
   - '--all'
   env:
   - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${COMMIT_SHA}'
 
-# delete everything in the opentelemetry namespace
-- name: 'gcr.io/cloud-builders/kubectl'
-  id: TearDown
+# delete the GKE cluster
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: DeleteCluster
   args:
+  - 'container'
+  - 'clusters'
   - 'delete'
-  - 'all'
-  - '--all'
-  - '-n'
-  - 'opentelemetry'
-  env:
-  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
-
-# delete the opentelemetry namespace
-- name: 'gcr.io/cloud-builders/kubectl'
-  id: DeleteNamespace
-  args:
-  - 'delete'
-  - 'namespace'
-  - 'opentelemetry'
-  env:
-  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+  - '${COMMIT_SHA}'
+  - '--zone=${LOCATION}'
+  - '--quiet'


### PR DESCRIPTION
This PR adds a Cloud Build script that does the following:
- Deploy to a pre-existing GKE cluster the manifests
- Asserts that the OTel collector pods become ready
- Tears down the collector deployment
- Deletes the namespace it created when it applied the manifests

The next step is having the presubmits use this cloud build script to test whenever a PR is created on the repo.