### PR TITLE
VERSION: add a version file and use it to update user agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,14 @@ manifests to do the following:
 * Update the collector deployment to a replicaset (for easier access via pod
   name in testing)
 
+### Versioning
+
+The manifest and collector version being used can be found in the `VERSION`
+file. Do not update this file manually. Instead the following commands to update
+the versions:
+  - To update the collector version run `OTEL_VERSION=<otel version> make update-otel-version`
+  - To update the manifests version run `VERSION=<manifests version> make update-manifests-version`
+
 ## Testing
 
 Fixture-based tests (deterministic input-output diff checking of signals) use

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ update-otel-version:
 	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" config/*; \
 	sed -i "s|COLLECTOR_CONTRIB_VERSION=[0-9.]\+|COLLECTOR_CONTRIB_VERSION=$(OTEL_VERSION)|g" VERSION; \
 	$(MAKE) generate; \
+	sed -i "s|app.kubernetes.io/version: \"[0-9.]\+\"|app.kubernetes.io/version: \"$(OTEL_VERSION)\"|g" k8s/base/*; \
 	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" k8s/base/*
 
 VERSION?=$(MANIFESTS_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-COLLECTOR_CONTRIB_VERSION=0.99.0
+include VERSION
 
 TOOLS = $(CURDIR)/.tools
 
@@ -40,6 +40,23 @@ $(TOOLS)/kubectl: $(TOOLS)
 
 .PHONY: tools
 tools: $(JQ) $(YQ) $(KUBECTL)
+
+OTEL_VERSION?=$(COLLECTOR_CONTRIB_VERSION)
+.PHONY: update-otel-version
+update-otel-version:
+	OLD_VERSION=$(shell grep -Eo 'COLLECTOR_CONTRIB_VERSION=[0-9.]+' VERSION | cut -d'=' -f2); \
+	sed -i "s|otel/opentelemetry-collector-contrib:$${OLD_VERSION}|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" config/*; \
+	sed -i "s|COLLECTOR_CONTRIB_VERSION=$${OLD_VERSION}|COLLECTOR_CONTRIB_VERSION=$(OTEL_VERSION)|g" VERSION; \
+	$(MAKE) generate; \
+	sed -i "s|otel/opentelemetry-collector-contrib:$${OLD_VERSION}|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" k8s/base/*
+
+VERSION?=$(MANIFESTS_VERSION)
+.PHONY: update-manifests-version
+update-manifests-version:
+	OLD_VERSION=$(shell grep -Eo 'MANIFESTS_VERSION=[0-9.]+' VERSION | cut -d'=' -f2); \
+	sed -i "s|manifests:$${OLD_VERSION}|manifests:$(VERSION)|g" config/*; \
+	sed -i "s|MANIFESTS_VERSION=$${OLD_VERSION}|MANIFESTS_VERSION=$(VERSION)|g" VERSION; \
+	$(MAKE) generate
 
 .PHONY: generate
 generate: tools

--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,16 @@ tools: $(JQ) $(YQ) $(KUBECTL)
 OTEL_VERSION?=$(COLLECTOR_CONTRIB_VERSION)
 .PHONY: update-otel-version
 update-otel-version:
-	OLD_VERSION=$(shell grep -Eo 'COLLECTOR_CONTRIB_VERSION=[0-9.]+' VERSION | cut -d'=' -f2); \
-	sed -i "s|otel/opentelemetry-collector-contrib:$${OLD_VERSION}|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" config/*; \
-	sed -i "s|COLLECTOR_CONTRIB_VERSION=$${OLD_VERSION}|COLLECTOR_CONTRIB_VERSION=$(OTEL_VERSION)|g" VERSION; \
+	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" config/*; \
+	sed -i "s|COLLECTOR_CONTRIB_VERSION=[0-9.]\+|COLLECTOR_CONTRIB_VERSION=$(OTEL_VERSION)|g" VERSION; \
 	$(MAKE) generate; \
-	sed -i "s|otel/opentelemetry-collector-contrib:$${OLD_VERSION}|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" k8s/base/*
+	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" k8s/base/*
 
 VERSION?=$(MANIFESTS_VERSION)
 .PHONY: update-manifests-version
 update-manifests-version:
-	OLD_VERSION=$(shell grep -Eo 'MANIFESTS_VERSION=[0-9.]+' VERSION | cut -d'=' -f2); \
-	sed -i "s|manifests:$${OLD_VERSION}|manifests:$(VERSION)|g" config/*; \
-	sed -i "s|MANIFESTS_VERSION=$${OLD_VERSION}|MANIFESTS_VERSION=$(VERSION)|g" VERSION; \
+	sed -i "s|manifests:[0-9.]\+|manifests:$(VERSION)|g" config/*; \
+	sed -i "s|MANIFESTS_VERSION=[0-9.]\+|MANIFESTS_VERSION=$(VERSION)|g" VERSION; \
 	$(MAKE) generate
 
 .PHONY: generate

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,8 @@
+# Do not update this file manually. Instead the following commands to update the
+# versions:
+#
+#  OTEL_VERSION=<otel version> make update-otel-version
+#  VERSION=<manifests version> make update-manifests-version
+
+MANIFESTS_VERSION=0.1.0
+COLLECTOR_CONTRIB_VERSION=0.99.0

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -73,7 +73,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.1.0
+        new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
       - action: aggregate_labels
         aggregation_type: sum
         label_set:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,7 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
   googlemanagedprometheus:
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
 
 extensions:
   health_check:
@@ -63,6 +65,20 @@ processors:
     check_interval: 1s
     limit_percentage: 65
     spike_limit_percentage: 20
+
+  metricstransform/self-metrics:
+    transforms:
+    - action: update
+      include: otelcol_process_uptime
+      new_name: agent/uptime
+      operations:
+      - action: add_label
+        new_label: version
+        new_value: Google-Cloud-OTLP manifests:0.1.0
+      - action: aggregate_labels
+        aggregation_type: sum
+        label_set:
+        - version
 
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:
@@ -149,6 +165,7 @@ service:
       - googlemanagedprometheus
       processors:
       - filter/self-metrics
+      - metricstransform/self-metrics
       - resource/self-metrics
       - k8sattributes
       - memory_limiter

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -74,10 +74,6 @@ processors:
       - action: add_label
         new_label: version
         new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
-      - action: aggregate_labels
-        aggregation_type: sum
-        label_set:
-        - version
 
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -70,7 +70,6 @@ processors:
     transforms:
     - action: update
       include: otelcol_process_uptime
-      new_name: agent/uptime
       operations:
       - action: add_label
         new_label: version

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -77,10 +77,6 @@ data:
           - action: add_label
             new_label: version
             new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set:
-            - version
 
       # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
       resource/self-metrics:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -73,7 +73,6 @@ data:
         transforms:
         - action: update
           include: otelcol_process_uptime
-          new_name: agent/uptime
           operations:
           - action: add_label
             new_label: version

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -76,7 +76,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0
+            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
           - action: aggregate_labels
             aggregation_type: sum
             label_set:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,7 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
+        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
       googlemanagedprometheus:
+        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
 
     extensions:
       health_check:
@@ -66,6 +68,20 @@ data:
         check_interval: 1s
         limit_percentage: 65
         spike_limit_percentage: 20
+
+      metricstransform/self-metrics:
+        transforms:
+        - action: update
+          include: otelcol_process_uptime
+          new_name: agent/uptime
+          operations:
+          - action: add_label
+            new_label: version
+            new_value: Google-Cloud-OTLP manifests:0.1.0
+          - action: aggregate_labels
+            aggregation_type: sum
+            label_set:
+            - version
 
       # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
       resource/self-metrics:
@@ -152,6 +168,7 @@ data:
           - googlemanagedprometheus
           processors:
           - filter/self-metrics
+          - metricstransform/self-metrics
           - resource/self-metrics
           - k8sattributes
           - memory_limiter

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,7 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
   googlemanagedprometheus:
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
   file:
     path: /output/output.json
 extensions:
@@ -62,6 +64,19 @@ processors:
     check_interval: 1s
     limit_percentage: 65
     spike_limit_percentage: 20
+  metricstransform/self-metrics:
+    transforms:
+      - action: update
+        include: otelcol_process_uptime
+        new_name: agent/uptime
+        operations:
+          - action: add_label
+            new_label: version
+            new_value: Google-Cloud-OTLP manifests:0.1.0
+          - action: aggregate_labels
+            aggregation_type: sum
+            label_set:
+              - version
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:
     attributes:
@@ -147,6 +162,7 @@ service:
         - googlemanagedprometheus
       processors:
         - filter/self-metrics
+        - metricstransform/self-metrics
         - resource/self-metrics
         - k8sattributes
         - memory_limiter

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -71,7 +71,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0
+            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
           - action: aggregate_labels
             aggregation_type: sum
             label_set:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -68,7 +68,6 @@ processors:
     transforms:
       - action: update
         include: otelcol_process_uptime
-        new_name: agent/uptime
         operations:
           - action: add_label
             new_label: version

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -72,10 +72,6 @@ processors:
           - action: add_label
             new_label: version
             new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.99.0
-          - action: aggregate_labels
-            aggregation_type: sum
-            label_set:
-              - version
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:
     attributes:


### PR DESCRIPTION
Fixes: b/346605126

This change does the following:
- Creates a VERSION file that captures the manifest version and the collector version
- Creates a user agent of the format `Google-Cloud-OTLP manifests:<MANIFESTS_VERSION> otel/opentelemetry-collector-contrib:<COLLECTOR_CONTRIB_VERSION>`
- Adds make targets to easily update the manifest and otel versions
- Update the uptime metric to have the version label (similar to the Ops Agent and the run-gmp-sidecar)