### PR TITLE
Change deployment to one-liner without needing clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,14 @@ gcloud iam service-accounts add-iam-policy-binding opentelemetry-collector@${GCL
 ### Install the manifests
 
 First, make sure you have followed the Workload Identity setup steps above.
-Update the manifests to annotate the Kubernetes service account with
-your project:
+
+Then, apply the Kubernetes manifests directly from this repo:
 
 ```console
-sed -i "s/%GCLOUD_PROJECT%/${GCLOUD_PROJECT}/g" k8s/base/*
+kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
 ```
 
-Install the manifests:
-
-```console
-kubectl apply -k k8s/base
-```
+(Remember to set the `GCLOUD_PROJECT` environment variable.)
 
 ### [Optional] Run the OpenTelemetry demo application alongside the collector
 

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   name: opentelemetry-collector
   namespace: opentelemetry
   annotations:
-    iam.gke.io/gcp-service-account: "opentelemetry-collector@%GCLOUD_PROJECT%.iam.gserviceaccount.com"
+    iam.gke.io/gcp-service-account: "opentelemetry-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com"
   labels:
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/version: "0.99.0"


### PR DESCRIPTION
This removes the need for the `sed` command and allows users to deploy the manifests without cloning the git repo.