### PR TITLE
Remove unnecessary resource attribute processor

### DIFF
--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -82,11 +82,6 @@ processors:
       key: k8s.pod.ip
       value: ${env:MY_POD_IP}
 
-  resource:
-    attributes:
-    - action: insert
-      from_attribute: k8s.pod.uid
-      key: service.instance.id
   resourcedetection:
     detectors: [gcp]
     timeout: 10s
@@ -138,7 +133,6 @@ service:
       processors:
       - k8sattributes
       - resourcedetection
-      - resource
       - memory_limiter
       - batch
       receivers:
@@ -151,7 +145,6 @@ service:
       - memory_limiter
       - resourcedetection
       - transform/collision
-      - resource
       - batch
       receivers:
       - otlp
@@ -165,7 +158,6 @@ service:
       - k8sattributes
       - memory_limiter
       - resourcedetection
-      - resource
       - batch
       receivers:
       - prometheus/self-metrics
@@ -176,7 +168,6 @@ service:
       - k8sattributes
       - memory_limiter
       - resourcedetection
-      - resource
       - batch
       receivers:
       - otlp

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -85,11 +85,6 @@ data:
           key: k8s.pod.ip
           value: ${env:MY_POD_IP}
 
-      resource:
-        attributes:
-        - action: insert
-          from_attribute: k8s.pod.uid
-          key: service.instance.id
       resourcedetection:
         detectors: [gcp]
         timeout: 10s
@@ -141,7 +136,6 @@ data:
           processors:
           - k8sattributes
           - resourcedetection
-          - resource
           - memory_limiter
           - batch
           receivers:
@@ -154,7 +148,6 @@ data:
           - memory_limiter
           - resourcedetection
           - transform/collision
-          - resource
           - batch
           receivers:
           - otlp
@@ -168,7 +161,6 @@ data:
           - k8sattributes
           - memory_limiter
           - resourcedetection
-          - resource
           - batch
           receivers:
           - prometheus/self-metrics
@@ -179,7 +171,6 @@ data:
           - k8sattributes
           - memory_limiter
           - resourcedetection
-          - resource
           - batch
           receivers:
           - otlp

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -78,11 +78,6 @@ processors:
       - action: insert
         key: k8s.pod.ip
         value: ${env:MY_POD_IP}
-  resource:
-    attributes:
-      - action: insert
-        from_attribute: k8s.pod.uid
-        key: service.instance.id
   resourcedetection:
     detectors: [gcp]
     timeout: 10s
@@ -135,7 +130,6 @@ service:
       processors:
         - k8sattributes
         - resourcedetection
-        - resource
         - memory_limiter
         - batch
       receivers:
@@ -148,7 +142,6 @@ service:
         - memory_limiter
         - resourcedetection
         - transform/collision
-        - resource
         - batch
       receivers:
         - otlp
@@ -162,7 +155,6 @@ service:
         - k8sattributes
         - memory_limiter
         - resourcedetection
-        - resource
         - batch
       receivers:
         - prometheus/self-metrics
@@ -173,7 +165,6 @@ service:
         - k8sattributes
         - memory_limiter
         - resourcedetection
-        - resource
         - batch
       receivers:
         - otlpjsonfile


### PR DESCRIPTION
This was copied from the upstream demo which uses it to make sure `service.instance.id` is set.

However, in our exporters we only use `service.instance.id` for [`genericTask`](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/648a71ca81a051f32a3accc68c62f60c75469822/internal/resourcemapping/resourcemapping.go#L153). Since this is intended to be run on GKE, we should have enough resource detection info to at least identify the signals as `k8s_cluster`, meaning there isn't a reason for us to be manually copying the Pod UID to instance ID.