### PR TITLE
Update collector to v0.106.0, and add intToDouble feature gate

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,4 +5,4 @@
 #  VERSION=<manifests version> make update-manifests-version
 
 MANIFESTS_VERSION=0.1.0
-COLLECTOR_CONTRIB_VERSION=0.105.0
+COLLECTOR_CONTRIB_VERSION=0.106.0

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
 
 extensions:
   health_check:
@@ -73,7 +73,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+        new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
 
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
 
     extensions:
       health_check:
@@ -76,7 +76,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
 
       # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
       resource/self-metrics:

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -21,7 +21,7 @@ metadata:
     iam.gke.io/gcp-service-account: "opentelemetry-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com"
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.105.0"
+    app.kubernetes.io/version: "0.106.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,7 +30,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.105.0"
+    app.kubernetes.io/version: "0.106.0"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -48,7 +48,7 @@ metadata:
   name: opentelemetry-collector
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.105.0"
+    app.kubernetes.io/version: "0.106.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,10 +35,11 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: otel/opentelemetry-collector-contrib:0.105.0
+        image: otel/opentelemetry-collector-contrib:0.106.0
         command:
           - "/otelcol-contrib"
           - "--config=/conf/collector.yaml"
+          - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"
         ports:
           - name: otlp-grpc
             containerPort: 4317

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
   file:
     path: /output/output.json
 extensions:
@@ -71,7 +71,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.105.0
+            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
   # We need to add the pod IP as a resource label so the k8s attributes processor can find it.
   resource/self-metrics:
     attributes:


### PR DESCRIPTION
This will mean new users of the samples write all metrics as double, which prevents errors for having mismatched types.