### PR TITLE
deployment: make otel container use args

### DIFF
--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -36,8 +36,7 @@ spec:
       - name: opentelemetry-collector
         imagePullPolicy: Always
         image: otel/opentelemetry-collector-contrib:0.106.0
-        command:
-          - "/otelcol-contrib"
+        args:
           - "--config=/conf/collector.yaml"
           - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"
         ports:


### PR DESCRIPTION
Fixes #23

It is common in other OTel Collector k8s deployments to assume that `CMD` for the container is going to contain the otel collector binary and to simply apply args. (If you are in CNCF Slack `#otel-operator` channel, see [this
thread](https://cloud-native.slack.com/archives/C033BJ8BASU/p1728327750985359)). This PR switches the `opentelemetry-collector` `container` in the deployment to use args instead of command, and maintain this assumption about the `CMD` of the container being correct. This means other properly formed collector container images can be used as a drop-in for the deployment.