### PR TITLE
Apply HPA to the collector deployment

### DIFF
--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -52,6 +52,12 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: status.podIP
+        resources:
+          requests:
+            memory: "200Mi"
+            cpu: "200m"
+          limits:
+            memory: "400Mi"
         volumeMounts:
           - name: collector-config
             mountPath: /conf

--- a/k8s/base/5_hpa.yaml
+++ b/k8s/base/5_hpa.yaml
@@ -22,7 +22,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: opentelemetry-collector
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 10
   metrics:
     - type: Resource
@@ -30,10 +30,10 @@ spec:
         name: memory
         target:
           type: Utilization
-          averageUtilization: 50
+          averageUtilization: 80
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 50
+          averageUtilization: 80

--- a/k8s/base/kustomization.yml
+++ b/k8s/base/kustomization.yml
@@ -20,3 +20,4 @@ resources:
   - 2_rbac.yaml
   - 3_service.yaml
   - 4_deployment.yaml
+  - 5_hpa.yaml


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/issues/25

In order for HPA to have an effect, requests need to be set on the collector.  In order for the memory_limiter to do anything, memory limits need to be set.

I also lowered the minimum replicas to 1, and increased the target utilization.  Since our memory limits are much higher than requests, this means that we still won't be at risk of hitting our limits.