### PR TITLE
[otlpmetric branch] migrate sample to use otlphttp for metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ First, make sure you have followed the Workload Identity setup steps above.
 Then, apply the Kubernetes manifests directly from this repo:
 
 ```console
-kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
+export GCP_REGION=<your region>
+kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base?ref=otlpmetric | envsubst | kubectl apply -f -
 ```
 
 (Remember to set the `GCLOUD_PROJECT` environment variable.)

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 steps:
-# set the project ID in the k8s manifest for service account/workload identity
+# perform environment variable substitution using cloud build-provided env vars.
+# LOCATION and PROJECT_ID are provided by default by cloud build.
+# Users use envsubst to do this in the same step as kubectl apply.
 - name: 'ubuntu'
   id: Replace
   script: |

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -18,8 +18,8 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" k8s/base/*
-    sed -i "s/%GCP_REGION%/${LOCATION}/g" k8s/base/*
+    grep -rlZ GCLOUD_PROJECT k8s/base/. | xargs -0 sed -i "s/\${GCLOUD_PROJECT}/$PROJECT_ID/g"
+    grep -rlZ GCP_REGION k8s/base/. | xargs -0 sed -i "s/\${GCP_REGION}/$LOCATION/g"
   env:
   - 'LOCATION=$LOCATION'
   - 'PROJECT_ID=$PROJECT_ID'

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -19,7 +19,9 @@ steps:
   script: |
     #!/usr/bin/env bash
     sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" k8s/base/*
+    sed -i "s/%GCP_REGION%/${LOCATION}/g" k8s/base/*
   env:
+  - 'LOCATION=$LOCATION'
   - 'PROJECT_ID=$PROJECT_ID'
 
 # create a GKE cluster

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -22,11 +22,23 @@ data:
         user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
       googlemanagedprometheus:
         user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.106.0
+      otlphttp:
+        encoding: json
+        endpoint: https://telemetry.${GCP_REGION}.rep.googleapis.com
+        auth:
+          authenticator: googleclientauth
 
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+      googleclientauth:
+
     processors:
+      resource/gcp_project_id:
+        attributes:
+        - action: insert
+          value: ${GCLOUD_PROJECT}
+          key: gcp.project_id
       filter/self-metrics:
         metrics:
           include:
@@ -129,6 +141,7 @@ data:
     service:
       extensions:
       - health_check
+      - googleclientauth
       pipelines:
         logs:
           exporters:
@@ -142,10 +155,11 @@ data:
           - otlp
         metrics/otlp:
           exporters:
-          - googlemanagedprometheus
+          - otlphttp
           processors:
           - k8sattributes
           - memory_limiter
+          - resource/gcp_project_id
           - resourcedetection
           - transform/collision
           - batch
@@ -153,13 +167,14 @@ data:
           - otlp
         metrics/self-metrics:
           exporters:
-          - googlemanagedprometheus
+          - otlphttp
           processors:
           - filter/self-metrics
           - metricstransform/self-metrics
           - resource/self-metrics
           - k8sattributes
           - memory_limiter
+          - resource/gcp_project_id
           - resourcedetection
           - batch
           receivers:


### PR DESCRIPTION
This doesn't change the main branch.  Tested on a GKE cluster