### PR TITLE
Simplify workload identity setup

### DIFF
--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -17,8 +17,6 @@ kind: ServiceAccount
 metadata:
   name: opentelemetry-collector
   namespace: opentelemetry
-  annotations:
-    iam.gke.io/gcp-service-account: "opentelemetry-collector@${GCLOUD_PROJECT}.iam.gserviceaccount.com"
   labels:
     app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/version: "0.106.0"


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/issues

Tested by deploying without permissions, and then running the workload identity commands and verifying that permissions issues are fixed.