### PR TITLE
Use structured logging so that logs are properly formatted in the logging UI

### DIFF
--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -175,6 +175,8 @@ data:
           receivers:
           - otlp
       telemetry:
+        logs:
+          encoding: json
         metrics:
           address: ${env:MY_POD_IP}:8888
 kind: ConfigMap


### PR DESCRIPTION
This makes all logs no longer appear as errors in the logging UI