### PR TITLE
Add interval processor to avoid errors from points written too frequently

### DIFF
--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -41,6 +41,9 @@ data:
         send_batch_size: 200
         timeout: 5s
 
+      interval:
+        interval: 5s
+
       k8sattributes:
         extract:
           metadata:
@@ -144,6 +147,7 @@ data:
           exporters:
           - googlemanagedprometheus
           processors:
+          - interval
           - k8sattributes
           - memory_limiter
           - resourcedetection


### PR DESCRIPTION
blocked on updating the collector version.

fixes https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/issues/32