### PR TITLE
Inject AppHub labels for GKE

### DIFF
--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -47,6 +47,7 @@ processors:
       - k8s.daemonset.name
       - k8s.cronjob.name
       - k8s.job.name
+      - k8s.replicaset.name
       - k8s.node.name
       - k8s.pod.name
       - k8s.pod.uid
@@ -96,6 +97,23 @@ processors:
       - set(attributes["exported_project_id"], attributes["project_id"])
       - delete_key(attributes, "project_id")
 
+  transform/aco-gke:
+    metric_statements:
+    - context: datapoint
+      statements:
+      - set(attributes["top_level_controller_type"], "deployment") where resource.attributes["k8s.deployment.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+      - set(attributes["top_level_controller_type"], "daemonset") where resource.attributes["k8s.daemonset.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.daemonset.name"] != nil
+      - set(attributes["top_level_controller_type"], "statefulset") where resource.attributes["k8s.statefulset.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.statefulset.name"] != nil
+      - set(attributes["top_level_controller_type"], "replicaset") where resource.attributes["k8s.replicaset.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.replicaset.name"] != nil
+      - set(attributes["top_level_controller_type"], "job") where resource.attributes["k8s.job.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
+      - set(attributes["top_level_controller_type"], "cronjob") where resource.attributes["k8s.cronjob.name"] != nil
+      - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
+
 receivers:
   otlp:
     protocols:
@@ -134,6 +152,7 @@ service:
       - memory_limiter
       - resourcedetection
       - transform/collision
+      - transform/aco-gke
       - batch
       receivers:
       - otlp

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -50,6 +50,7 @@ data:
           - k8s.daemonset.name
           - k8s.cronjob.name
           - k8s.job.name
+          - k8s.replicaset.name
           - k8s.node.name
           - k8s.pod.name
           - k8s.pod.uid
@@ -105,6 +106,16 @@ data:
           statements:
           - set(attributes["top_level_controller_type"], "deployment") where resource.attributes["k8s.deployment.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+          - set(attributes["top_level_controller_type"], "daemonset") where resource.attributes["k8s.daemonset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.daemonset.name"] != nil
+          - set(attributes["top_level_controller_type"], "statefulset") where resource.attributes["k8s.statefulset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.statefulset.name"] != nil
+          - set(attributes["top_level_controller_type"], "replicaset") where resource.attributes["k8s.replicaset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.replicaset.name"] != nil
+          - set(attributes["top_level_controller_type"], "job") where resource.attributes["k8s.job.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
+          - set(attributes["top_level_controller_type"], "cronjob") where resource.attributes["k8s.cronjob.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 
     receivers:
       otlp:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -99,6 +99,13 @@ data:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
+      transform/aco-gke:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["top_level_controller_type"], "deployment") where resource.attributes["k8s.deployment.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+
     receivers:
       otlp:
         protocols:
@@ -137,6 +144,7 @@ data:
           - memory_limiter
           - resourcedetection
           - transform/collision
+          - transform/aco-gke
           - batch
           receivers:
           - otlp

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -46,6 +46,7 @@ processors:
         - k8s.daemonset.name
         - k8s.cronjob.name
         - k8s.job.name
+        - k8s.replicaset.name
         - k8s.node.name
         - k8s.pod.name
         - k8s.pod.uid
@@ -91,6 +92,22 @@ processors:
           - delete_key(attributes, "instance")
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
+  transform/aco-gke:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(attributes["top_level_controller_type"], "deployment") where resource.attributes["k8s.deployment.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+          - set(attributes["top_level_controller_type"], "daemonset") where resource.attributes["k8s.daemonset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.daemonset.name"]) where resource.attributes["k8s.daemonset.name"] != nil
+          - set(attributes["top_level_controller_type"], "statefulset") where resource.attributes["k8s.statefulset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.statefulset.name"]) where resource.attributes["k8s.statefulset.name"] != nil
+          - set(attributes["top_level_controller_type"], "replicaset") where resource.attributes["k8s.replicaset.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.replicaset.name"]) where resource.attributes["k8s.replicaset.name"] != nil
+          - set(attributes["top_level_controller_type"], "job") where resource.attributes["k8s.job.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
+          - set(attributes["top_level_controller_type"], "cronjob") where resource.attributes["k8s.cronjob.name"] != nil
+          - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 receivers:
   otlp:
     protocols:
@@ -132,6 +149,7 @@ service:
         - memory_limiter
         - resourcedetection
         - transform/collision
+        - transform/aco-gke
         - batch
       receivers:
         - otlp


### PR DESCRIPTION
#### Description
Add a transform processor to inject metric labels in otlp metrics describing k8s deployment on GKE. Labels are injected on following GKE resources: 
 - Deployment
 - DaemonSet
 - StatefulSet
 - ReplicaSet
 - Job
 - CronJob

The resource type `ReplicationController` was excluded since it is a [legacy API superseded by Deployment and ReplicaSet APIs](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/). 

Additionally, the [k8s attributes processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor) does not support this resource type. 

#### Testing
 - Used a collector instance with the updated collector config to collect metrics from an auto-instrumented application running on GKE cluster.
 - Verified that the resulting GKE metrics contained the newly added metric attributes.
 - `make generate` indicates generated changes are in-sync.