### PR TITLE
Update collector to use Google Built OpenTelemetry Collector v0.121.0

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -5,4 +5,4 @@
 #  VERSION=<manifests version> make update-manifests-version
 
 MANIFESTS_VERSION=0.1.0
-COLLECTOR_CONTRIB_VERSION=0.118.0
+COLLECTOR_CONTRIB_VERSION=0.121.0

--- a/VERSION
+++ b/VERSION
@@ -4,5 +4,5 @@
 #  OTEL_VERSION=<otel version> make update-otel-version
 #  VERSION=<manifests version> make update-manifests-version
 
-MANIFESTS_VERSION=0.1.0
+MANIFESTS_VERSION=0.2.0
 COLLECTOR_CONTRIB_VERSION=0.121.0

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
 extensions:
   health_check:
@@ -74,7 +74,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
   resourcedetection:
     detectors: [gcp]
@@ -191,5 +191,5 @@ service:
       - periodic:
           exporter:
             otlp:
-              protocol: grpc/protobuf
+              protocol: grpc
               endpoint: ${env:MY_POD_IP}:14317

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
 extensions:
   health_check:
@@ -74,7 +74,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+        new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
   resourcedetection:
     detectors: [gcp]

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
 extensions:
   health_check:
@@ -74,7 +74,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
     extensions:
       health_check:
@@ -77,7 +77,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+            new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
       resourcedetection:
         detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
     extensions:
       health_check:
@@ -77,7 +77,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+            new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
 
       resourcedetection:
         detectors: [gcp]
@@ -194,7 +194,7 @@ data:
           - periodic:
               exporter:
                 otlp:
-                  protocol: grpc/protobuf
+                  protocol: grpc
                   endpoint: ${env:MY_POD_IP}:14317
 kind: ConfigMap
 metadata:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
     extensions:
       health_check:
@@ -77,7 +77,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -194,7 +194,7 @@ data:
           - periodic:
               exporter:
                 otlp:
-                  protocol: grpc/protobuf
+                  protocol: grpc
                   endpoint: ${env:MY_POD_IP}:14317
 kind: ConfigMap
 metadata:

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.121.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,7 +28,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.121.0"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -46,7 +46,7 @@ metadata:
   name: opentelemetry-collector
   labels:
     app.kubernetes.io/name: opentelemetry-collector
-    app.kubernetes.io/version: "0.118.0"
+    app.kubernetes.io/version: "0.121.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:v0.121.0
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.121.0
         args:
           - "--config=/conf/collector.yaml"
           - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: otel/opentelemetry-collector-contrib:0.118.0
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:v0.121.0
         args:
           - "--config=/conf/collector.yaml"
           - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   file:
     path: /output/output.json
 extensions:
@@ -72,7 +72,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+            new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   resourcedetection:
     detectors: [gcp]
     timeout: 10s
@@ -188,5 +188,5 @@ service:
         - periodic:
             exporter:
               otlp:
-                protocol: grpc/protobuf
+                protocol: grpc
                 endpoint: ${env:MY_POD_IP}:14317

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   file:
     path: /output/output.json
 extensions:
@@ -72,7 +72,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
+            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   file:
     path: /output/output.json
 extensions:
@@ -72,7 +72,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.1.0 otel/opentelemetry-collector-contrib:0.118.0
+            new_value: Google-Cloud-OTLP manifests:0.3.0 google-built-otel/opentelemetry-collector-contrib:0.121.0
   resourcedetection:
     detectors: [gcp]
     timeout: 10s

--- a/sample/app.yaml
+++ b/sample/app.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
         - name: traces
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.105.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
           args: ["traces", "--otlp-insecure", "--rate=3", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:
@@ -64,7 +64,7 @@ spec:
             limits:
               memory: 100Mi
         - name: metrics
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.105.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
           args: ["metrics", "--otlp-insecure", "--rate=0.1", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:
@@ -85,7 +85,7 @@ spec:
             limits:
               memory: 100Mi
         - name: logs
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.105.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
           args: ["logs", "--otlp-insecure", "--rate=3", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:


### PR DESCRIPTION
Upgraded collector to Google Built OpenTelemetry Collector v0.121.0 and added a marker as 0.3.0 for the Google User agent