### PR TITLE
Update Collector Config to use OTLP exporters for Trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project contains Kubernetes manifests for self-deployed OTLP ingest on Kube
 
 Before we begin, set required environment variables:
 ```console
-export PROJECT_ID=<your project id>
+export GCLOUD_PROJECT=<your project id>
 export PROJECT_NUMBER=<your project number>
 ```
 
@@ -19,17 +19,17 @@ docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
 to allow the collector's kubernetes service account to write logs, traces, and metrics:
 
 ```console
-gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
     --role=roles/logging.logWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
     --role=roles/monitoring.metricWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
+gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
     --role=roles/cloudtrace.agent \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
 ```
 
@@ -43,7 +43,7 @@ Then, apply the Kubernetes manifests directly from this repo:
 kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
 ```
 
-(Remember to set the `PROJECT_ID` environment variable.)
+(Remember to set the `GCLOUD_PROJECT` environment variable.)
 
 ### [Optional] Run the OpenTelemetry demo application alongside the collector
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project contains Kubernetes manifests for self-deployed OTLP ingest on Kube
 
 Before we begin, set required environment variables:
 ```console
-export GCLOUD_PROJECT=<your project id>
+export PROJECT_ID=<your project id>
 export PROJECT_NUMBER=<your project number>
 ```
 
@@ -19,17 +19,17 @@ docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
 to allow the collector's kubernetes service account to write logs, traces, and metrics:
 
 ```console
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
     --role=roles/logging.logWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
     --role=roles/monitoring.metricWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$PROJECT_ID \
     --role=roles/cloudtrace.agent \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$PROJECT_ID.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
 ```
 
@@ -43,7 +43,7 @@ Then, apply the Kubernetes manifests directly from this repo:
 kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
 ```
 
-(Remember to set the `GCLOUD_PROJECT` environment variable.)
+(Remember to set the `PROJECT_ID` environment variable.)
 
 ### [Optional] Run the OpenTelemetry demo application alongside the collector
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This project contains Kubernetes manifests for self-deployed OTLP ingest on Kube
 
 Before we begin, set required environment variables:
 ```console
-export GCLOUD_PROJECT=<your project id>
-export PROJECT_NUMBER=$(gcloud projects describe ${GCLOUD_PROJECT} --format="value(projectNumber)")
+export GOOGLE_CLOUD_PROJECT=<your project id>
+export PROJECT_NUMBER=$(gcloud projects describe ${GOOGLE_CLOUD_PROJECT} --format="value(projectNumber)")
 ```
 
 ### Configure IAM Permissions
@@ -19,17 +19,17 @@ docs](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)
 to allow the collector's kubernetes service account to write logs, traces, and metrics:
 
 ```console
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$GOOGLE_CLOUD_PROJECT \
     --role=roles/logging.logWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GOOGLE_CLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$GOOGLE_CLOUD_PROJECT \
     --role=roles/monitoring.metricWriter \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GOOGLE_CLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
-gcloud projects add-iam-policy-binding projects/$GCLOUD_PROJECT \
+gcloud projects add-iam-policy-binding projects/$GOOGLE_CLOUD_PROJECT \
     --role=roles/cloudtrace.agent \
-    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GCLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
+    --member=principal://iam.googleapis.com/projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$GOOGLE_CLOUD_PROJECT.svc.id.goog/subject/ns/opentelemetry/sa/opentelemetry-collector \
     --condition=None
 ```
 
@@ -43,7 +43,7 @@ Then, apply the Kubernetes manifests directly from this repo:
 kubectl kustomize https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/k8s/base | envsubst | kubectl apply -f -
 ```
 
-(Remember to set the `GCLOUD_PROJECT` environment variable.)
+(Remember to set the `GOOGLE_CLOUD_PROJECT` environment variable.)
 
 ### [Optional] Run the OpenTelemetry demo application alongside the collector
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project contains Kubernetes manifests for self-deployed OTLP ingest on Kube
 Before we begin, set required environment variables:
 ```console
 export GCLOUD_PROJECT=<your project id>
-export PROJECT_NUMBER=<your project number>
+export PROJECT_NUMBER=$(gcloud projects describe ${GCLOUD_PROJECT} --format="value(projectNumber)")
 ```
 
 ### Configure IAM Permissions

--- a/VERSION
+++ b/VERSION
@@ -4,5 +4,5 @@
 #  OTEL_VERSION=<otel version> make update-otel-version
 #  VERSION=<manifests version> make update-manifests-version
 
-MANIFESTS_VERSION=0.2.1
+MANIFESTS_VERSION=0.3.0
 COLLECTOR_CONTRIB_VERSION=0.121.0

--- a/VERSION
+++ b/VERSION
@@ -4,5 +4,5 @@
 #  OTEL_VERSION=<otel version> make update-otel-version
 #  VERSION=<manifests version> make update-manifests-version
 
-MANIFESTS_VERSION=0.2.0
+MANIFESTS_VERSION=0.2.1
 COLLECTOR_CONTRIB_VERSION=0.121.0

--- a/VERSION
+++ b/VERSION
@@ -7,4 +7,4 @@
 # Note: The manifests in these repositories use the Google Built OpenTelemetry Collector.
 
 MANIFESTS_VERSION=0.3.0
-GBOC_VERSION=0.121.0
+GBOC_VERSION=0.122.1

--- a/cloudbuild-e2e.yaml
+++ b/cloudbuild-e2e.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/\${GCLOUD_PROJECT}/${PROJECT_ID}/g" k8s/overlays/test/*
+    sed -i "s/\${GOOGLE_CLOUD_PROJECT}/${PROJECT_ID}/g" k8s/overlays/test/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-e2e.yaml
+++ b/cloudbuild-e2e.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/overlays/test/*
+    sed -i "s/\${GCLOUD_PROJECT}/${PROJECT_ID}/g" k8s/overlays/test/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-e2e.yaml
+++ b/cloudbuild-e2e.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/base/*
+    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/overlays/test/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-e2e.yaml
+++ b/cloudbuild-e2e.yaml
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 steps:
+# set the project ID in the k8s manifest for OTLP ingestion
+- name: 'ubuntu'
+  id: Replace
+  script: |
+    #!/usr/bin/env bash
+    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/base/*
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+
 # create a GKE cluster
 - name: 'gcr.io/cloud-builders/gcloud'
   id: CreateCluster

--- a/cloudbuild-e2e.yaml
+++ b/cloudbuild-e2e.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-# set the project ID in the k8s manifest for OTLP ingestion
+# set the project ID in the k8s manifest for OTLP export
 - name: 'ubuntu'
   id: Replace
   script: |

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" k8s/base/*
+    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/base/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/\${GCLOUD_PROJECT}/${PROJECT_ID}/g" k8s/base/*
+    sed -i "s/\${GOOGLE_CLOUD_PROJECT}/${PROJECT_ID}/g" k8s/base/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -18,7 +18,7 @@ steps:
   id: Replace
   script: |
     #!/usr/bin/env bash
-    sed -i "s/\${PROJECT_ID}/${PROJECT_ID}/g" k8s/base/*
+    sed -i "s/\${GCLOUD_PROJECT}/${PROJECT_ID}/g" k8s/base/*
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-# set the project ID in the k8s manifest for service account/workload identity
+# set the project ID in the k8s manifest for OTLP export
 - name: 'ubuntu'
   id: Replace
   script: |

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -19,10 +19,10 @@ exporters:
     user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
     user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
-  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
-    encoding: json
+    encoding: proto
     endpoint: https://telemetry.googleapis.com
     # Use the googleclientauth extension to authenticate with Google credentials
     auth:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -137,7 +137,7 @@ processors:
     attributes:
     - key: gcp.project_id
       # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-      value: ${PROJECT_ID}
+      value: ${GCLOUD_PROJECT}
       action: insert
 
 

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -32,6 +32,8 @@ exporters:
 extensions:
   health_check:
     endpoint: ${env:MY_POD_IP}:13133
+
+
 processors:
   filter/self-metrics:
     metrics:
@@ -71,6 +73,7 @@ processors:
         name: k8s.pod.uid
     - sources:
       - from: connection
+
   memory_limiter:
     check_interval: 1s
     limit_percentage: 65
@@ -129,12 +132,13 @@ processors:
       - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 
 # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
-resource/gcp_project_id:
+  resource/gcp_project_id:
     attributes:
     - action: insert
       # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-      value: ${GCLOUD_PROJECT}
+      value: ${PROJECT_ID}
       key: gcp.project_id
+
 
 receivers:
   otlp:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -134,10 +134,10 @@ processors:
 # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
   resource/gcp_project_id:
     attributes:
-    - action: insert
+    - key: gcp.project_id
       # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
       value: ${PROJECT_ID}
-      key: gcp.project_id
+      action: insert
 
 
 receivers:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -32,6 +32,7 @@ exporters:
 extensions:
   health_check:
     endpoint: ${env:MY_POD_IP}:13133
+  googleclientauth:
 
 
 processors:
@@ -159,6 +160,7 @@ receivers:
 service:
   extensions:
   - health_check
+  - googleclientauth
   pipelines:
     logs:
       exporters:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -83,7 +83,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -86,7 +86,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -87,7 +87,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -19,6 +19,15 @@ exporters:
     user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
     user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+  # The otlp exporter could also be used to send them using OTLP grpc
+  otlphttp:
+    encoding: json
+    endpoint: https://telemetry.googleapis.com
+    # Use the googleclientauth extension to authenticate with Google credentials
+    auth:
+      authenticator: googleclientauth
+
 
 extensions:
   health_check:
@@ -119,6 +128,14 @@ processors:
       - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
       - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 
+# When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
+resource/gcp_project_id:
+    attributes:
+    - action: insert
+      # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
+      value: ${GCLOUD_PROJECT}
+      key: gcp.project_id
+
 receivers:
   otlp:
     protocols:
@@ -175,10 +192,11 @@ service:
       - otlp/self-metrics
     traces:
       exporters:
-      - googlecloud
+      - otlphttp
       processors:
       - k8sattributes
       - memory_limiter
+      - resource/gcp_project_id
       - resourcedetection
       - batch
       receivers:

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -137,7 +137,7 @@ processors:
     attributes:
     - key: gcp.project_id
       # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-      value: ${GCLOUD_PROJECT}
+      value: ${GOOGLE_CLOUD_PROJECT}
       action: insert
 
 

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -35,6 +35,8 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+
+
     processors:
       filter/self-metrics:
         metrics:
@@ -74,6 +76,7 @@ data:
             name: k8s.pod.uid
         - sources:
           - from: connection
+
       memory_limiter:
         check_interval: 1s
         limit_percentage: 65
@@ -132,12 +135,13 @@ data:
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 
     # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
-    resource/gcp_project_id:
+      resource/gcp_project_id:
         attributes:
         - action: insert
           # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-          value: ${GCLOUD_PROJECT}
+          value: ${PROJECT_ID}
           key: gcp.project_id
+
 
     receivers:
       otlp:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
       # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
       # The otlp exporter could also be used to send them using OTLP grpc
       otlphttp:
@@ -89,7 +89,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -140,7 +140,7 @@ data:
         attributes:
         - key: gcp.project_id
           # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-          value: ${PROJECT_ID}
+          value: ${GCLOUD_PROJECT}
           action: insert
 
 

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -140,7 +140,7 @@ data:
         attributes:
         - key: gcp.project_id
           # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-          value: ${GCLOUD_PROJECT}
+          value: ${GOOGLE_CLOUD_PROJECT}
           action: insert
 
 

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
       # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
       # The otlp exporter could also be used to send them using OTLP grpc
       otlphttp:
@@ -90,7 +90,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
       # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
       # The otlp exporter could also be used to send them using OTLP grpc
       otlphttp:
@@ -86,7 +86,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -137,10 +137,10 @@ data:
     # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
       resource/gcp_project_id:
         attributes:
-        - action: insert
+        - key: gcp.project_id
           # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
           value: ${PROJECT_ID}
-          key: gcp.project_id
+          action: insert
 
 
     receivers:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -22,10 +22,10 @@ data:
         user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
       googlemanagedprometheus:
         user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
-      # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+      # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
       # The otlp exporter could also be used to send them using OTLP grpc
       otlphttp:
-        encoding: json
+        encoding: proto
         endpoint: https://telemetry.googleapis.com
         # Use the googleclientauth extension to authenticate with Google credentials
         auth:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -35,6 +35,7 @@ data:
     extensions:
       health_check:
         endpoint: ${env:MY_POD_IP}:13133
+      googleclientauth:
 
 
     processors:
@@ -162,6 +163,7 @@ data:
     service:
       extensions:
       - health_check
+      - googleclientauth
       pipelines:
         logs:
           exporters:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -22,6 +22,15 @@ data:
         user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
       googlemanagedprometheus:
         user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+      # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+      # The otlp exporter could also be used to send them using OTLP grpc
+      otlphttp:
+        encoding: json
+        endpoint: https://telemetry.googleapis.com
+        # Use the googleclientauth extension to authenticate with Google credentials
+        auth:
+          authenticator: googleclientauth
+
 
     extensions:
       health_check:
@@ -122,6 +131,14 @@ data:
           - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
 
+    # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
+    resource/gcp_project_id:
+        attributes:
+        - action: insert
+          # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
+          value: ${GCLOUD_PROJECT}
+          key: gcp.project_id
+
     receivers:
       otlp:
         protocols:
@@ -178,10 +195,11 @@ data:
           - otlp/self-metrics
         traces:
           exporters:
-          - googlecloud
+          - otlphttp
           processors:
           - k8sattributes
           - memory_limiter
+          - resource/gcp_project_id
           - resourcedetection
           - batch
           receivers:

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.122.1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,7 +28,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.122.1"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -46,7 +46,7 @@ metadata:
   name: opentelemetry-collector
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.122.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.121.0
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.122.1
         args:
           - "--config=/conf/collector.yaml"
           - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -124,10 +124,10 @@ processors:
           # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
   resource/gcp_project_id:
     attributes:
-      - action: insert
+      - key: gcp.project_id
         # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
         value: ${PROJECT_ID}
-        key: gcp.project_id
+        action: insert
 receivers:
   otlp:
     protocols:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -18,10 +18,10 @@ exporters:
     user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
     user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
-  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
-    encoding: json
+    encoding: proto
     endpoint: https://telemetry.googleapis.com
     # Use the googleclientauth extension to authenticate with Google credentials
     auth:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -80,7 +80,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -121,13 +121,13 @@ processors:
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
           - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
-# When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
-resource/gcp_project_id:
-  attributes:
-    - action: insert
-      # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-      value: ${GCLOUD_PROJECT}
-      key: gcp.project_id
+          # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
+  resource/gcp_project_id:
+    attributes:
+      - action: insert
+        # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
+        value: ${PROJECT_ID}
+        key: gcp.project_id
 receivers:
   otlp:
     protocols:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -18,6 +18,14 @@ exporters:
     user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
     user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+  # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
+  # The otlp exporter could also be used to send them using OTLP grpc
+  otlphttp:
+    encoding: json
+    endpoint: https://telemetry.googleapis.com
+    # Use the googleclientauth extension to authenticate with Google credentials
+    auth:
+      authenticator: googleclientauth
   file:
     path: /output/output.json
 extensions:
@@ -113,6 +121,13 @@ processors:
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
           - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
+# When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
+resource/gcp_project_id:
+  attributes:
+    - action: insert
+      # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
+      value: ${GCLOUD_PROJECT}
+      key: gcp.project_id
 receivers:
   otlp:
     protocols:
@@ -176,6 +191,7 @@ service:
       processors:
         - k8sattributes
         - memory_limiter
+        - resource/gcp_project_id
         - resourcedetection
         - batch
       receivers:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -127,7 +127,7 @@ processors:
     attributes:
       - key: gcp.project_id
         # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-        value: ${PROJECT_ID}
+        value: ${GCLOUD_PROJECT}
         action: insert
 receivers:
   otlp:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -127,7 +127,7 @@ processors:
     attributes:
       - key: gcp.project_id
         # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
-        value: ${GCLOUD_PROJECT}
+        value: ${GOOGLE_CLOUD_PROJECT}
         action: insert
 receivers:
   otlp:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -31,6 +31,7 @@ exporters:
 extensions:
   health_check:
     endpoint: ${env:MY_POD_IP}:13133
+  googleclientauth:
 processors:
   filter/self-metrics:
     metrics:
@@ -150,6 +151,7 @@ receivers:
 service:
   extensions:
     - health_check
+    - googleclientauth
   pipelines:
     logs:
       exporters:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -81,7 +81,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/json
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -80,7 +80,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.1 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s

--- a/sample/app.yaml
+++ b/sample/app.yaml
@@ -27,7 +27,7 @@ metadata:
     app.kubernetes.io/instance: telemetrygen
     app.kubernetes.io/component: collector-contrib
     app.kubernetes.io/name: collector-contrib-telemetrygen
-    app.kubernetes.io/version: "0.105.0"
+    app.kubernetes.io/version: "0.122.0"
     app.kubernetes.io/part-of: collector-contrib-telemetrygen
 spec:
   replicas: 1

--- a/sample/app.yaml
+++ b/sample/app.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
         - name: traces
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.122.0'
           args: ["traces", "--otlp-insecure", "--rate=3", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:
@@ -64,7 +64,7 @@ spec:
             limits:
               memory: 100Mi
         - name: metrics
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.122.0'
           args: ["metrics", "--otlp-insecure", "--rate=0.1", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:
@@ -85,7 +85,7 @@ spec:
             limits:
               memory: 100Mi
         - name: logs
-          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.121.0'
+          image: 'ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.122.0'
           args: ["logs", "--otlp-insecure", "--rate=3", "--duration=5m", "--otlp-endpoint=$(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)"]
           imagePullPolicy: IfNotPresent
           env:


### PR DESCRIPTION
Update the OTel Collector config to use OTLP HTTP exporter for Trace instead of `googlecloud` exporter.

The current collector config uses: 
1. `googlecloud` exporter for logs
2. `googlemanagedprometheus` exporter for metrics
3. `otlphttp` exporter for traces.