### PR TITLE
Update makefile rules to automate GBOC version updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,10 @@ manifests to do the following:
 The manifest and collector version being used can be found in the `VERSION`
 file. Do not update this file manually. Instead the following commands to update
 the versions:
-  - To update the collector version run `OTEL_VERSION=<otel version> make update-otel-version`
+  - To update the collector version run `OTEL_COLLECTOR_VERSION=<otel collector version> make update-otel-version`
   - To update the manifests version run `VERSION=<manifests version> make update-manifests-version`
+
+*Note: The manifests in this repository use the [Google Built OpenTelemetry Collector](https://github.com/GoogleCloudPlatform/opentelemetry-operations-collector/tree/master/google-built-opentelemetry-collector).*
 
 ## Testing
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ $(TOOLS)/kubectl: $(TOOLS)
 .PHONY: tools
 tools: $(JQ) $(YQ) $(KUBECTL)
 
-OTEL_COLLECTOR_VERSION?=$(GBOC_VERSION)
+OTEL_COLLECTOR_VERSION ?= $(GBOC_VERSION)
 .PHONY: update-otel-version
 update-otel-version:
 	sed -i "s|OpenTelemetry Collector Built By Google/[0-9.]\+|OpenTelemetry Collector Built By Google/$(OTEL_COLLECTOR_VERSION)|g" config/*; \
@@ -51,7 +51,7 @@ update-otel-version:
 	sed -i "s|us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:[0-9.]\+|us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:$(OTEL_COLLECTOR_VERSION)|g" k8s/base/*; \
 	sed -i "s|OpenTelemetry Collector Built By Google/[0-9.]\+|OpenTelemetry Collector Built By Google/$(OTEL_COLLECTOR_VERSION)|g" k8s/base/*;
 
-VERSION?=$(MANIFESTS_VERSION)
+VERSION ?= $(MANIFESTS_VERSION)
 .PHONY: update-manifests-version
 update-manifests-version:
 	sed -i "s|manifests:[0-9.]\+|manifests:$(VERSION)|g" config/*; \

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,15 @@ $(TOOLS)/kubectl: $(TOOLS)
 .PHONY: tools
 tools: $(JQ) $(YQ) $(KUBECTL)
 
-OTEL_VERSION?=$(COLLECTOR_CONTRIB_VERSION)
+OTEL_COLLECTOR_VERSION?=$(GBOC_VERSION)
 .PHONY: update-otel-version
 update-otel-version:
-	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" config/*; \
-	sed -i "s|COLLECTOR_CONTRIB_VERSION=[0-9.]\+|COLLECTOR_CONTRIB_VERSION=$(OTEL_VERSION)|g" VERSION; \
+	sed -i "s|OpenTelemetry Collector Built By Google/[0-9.]\+|OpenTelemetry Collector Built By Google/$(OTEL_COLLECTOR_VERSION)|g" config/*; \
+	sed -i "s|GBOC_VERSION=[0-9.]\+|GBOC_VERSION=$(OTEL_COLLECTOR_VERSION)|g" VERSION; \
 	$(MAKE) generate; \
-	sed -i "s|app.kubernetes.io/version: \"[0-9.]\+\"|app.kubernetes.io/version: \"$(OTEL_VERSION)\"|g" k8s/base/*; \
-	sed -i "s|otel/opentelemetry-collector-contrib:[0-9.]\+|otel/opentelemetry-collector-contrib:$(OTEL_VERSION)|g" k8s/base/*
+	sed -i "s|app.kubernetes.io/version: \"[0-9.]\+\"|app.kubernetes.io/version: \"$(OTEL_COLLECTOR_VERSION)\"|g" k8s/base/*; \
+	sed -i "s|us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:[0-9.]\+|us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:$(OTEL_COLLECTOR_VERSION)|g" k8s/base/*; \
+	sed -i "s|OpenTelemetry Collector Built By Google/[0-9.]\+|OpenTelemetry Collector Built By Google/$(OTEL_COLLECTOR_VERSION)|g" k8s/base/*;
 
 VERSION?=$(MANIFESTS_VERSION)
 .PHONY: update-manifests-version

--- a/VERSION
+++ b/VERSION
@@ -5,4 +5,4 @@
 #  VERSION=<manifests version> make update-manifests-version
 
 MANIFESTS_VERSION=0.2.0
-COLLECTOR_CONTRIB_VERSION=0.121.0
+GBOC_VERSION=0.121.0

--- a/VERSION
+++ b/VERSION
@@ -1,8 +1,10 @@
 # Do not update this file manually. Instead the following commands to update the
 # versions:
 #
-#  OTEL_VERSION=<otel version> make update-otel-version
+#  OTEL_COLLECTOR_VERSION=<otel collector version> make update-otel-version
 #  VERSION=<manifests version> make update-manifests-version
+#
+# Note: The manifests in these repositories use the Google Built OpenTelemetry Collector.
 
 MANIFESTS_VERSION=0.2.0
 GBOC_VERSION=0.121.0

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   name: opentelemetry-collector
   namespace: opentelemetry
   labels:
-    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/name: google-built-opentelemetry-collector
     app.kubernetes.io/version: "0.121.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,7 +27,7 @@ metadata:
   name: opentelemetry-collector
   namespace: opentelemetry
   labels:
-    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/name: google-built-opentelemetry-collector
     app.kubernetes.io/version: "0.121.0"
 rules:
   - apiGroups: [""]
@@ -45,7 +45,7 @@ kind: ClusterRoleBinding
 metadata:
   name: opentelemetry-collector
   labels:
-    app.kubernetes.io/name: opentelemetry-collector
+    app.kubernetes.io/name: google-built-opentelemetry-collector
     app.kubernetes.io/version: "0.121.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Updates the makefile rules responsible for auto-updating versions to match the recent changes made in the manifests.

### Testing:
 - Manually ran `OTEL_COLLECTOR_VERSION=0.123.0 make update-otel-version` to confirm that the produced changes were as expected.

#### Produced diff
```diff
diff --git a/VERSION b/VERSION
index 714cbcf..0b62e68 100644
--- a/VERSION
+++ b/VERSION
@@ -7,4 +7,4 @@
 # Note: The manifests in these repositories use the Google Built OpenTelemetry Collector.
 
 MANIFESTS_VERSION=0.2.0
-GBOC_VERSION=0.121.0
+GBOC_VERSION=0.123.0
diff --git a/config/collector.yaml b/config/collector.yaml
index 14621e2..c702579 100644
--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
 
 extensions:
   health_check:
@@ -74,7 +74,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]
diff --git a/k8s/base/1_configmap.yaml b/k8s/base/1_configmap.yaml
index 359e6c6..d173950 100644
--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
 
     extensions:
       health_check:
@@ -77,7 +77,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]
diff --git a/k8s/base/2_rbac.yaml b/k8s/base/2_rbac.yaml
index 74d0269..409a11b 100644
--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.123.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,7 +28,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.123.0"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -46,7 +46,7 @@ metadata:
   name: opentelemetry-collector
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.121.0"
+    app.kubernetes.io/version: "0.123.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
diff --git a/k8s/base/4_deployment.yaml b/k8s/base/4_deployment.yaml
index 8c59396..79bc1af 100644
--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.121.0
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.123.0
         args:
           - "--config=/conf/collector.yaml"
           - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"
diff --git a/k8s/overlays/test/collector.yaml b/k8s/overlays/test/collector.yaml
index d4229d9..fc44859 100644
--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
   file:
     path: /output/output.json
 extensions:
@@ -72,7 +72,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.121.0 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.2.0 OpenTelemetry Collector Built By Google/0.123.0 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s
```