### PR TITLE
[otlpmetric] update the collector version and use the metricstarttime processor

### DIFF
--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -158,6 +158,10 @@ data:
           value: ${GOOGLE_CLOUD_PROJECT}
           action: insert
 
+      # The metricstarttime processor is important to include if you are using the prometheus receiver to ensure the start time is set properly.
+      # It is a no-op otherwise.
+      metricstarttime:
+        strategy: subtract_initial_point
 
     receivers:
       # This collector is configured to accept OTLP metrics, logs, and traces, and is designed to receive OTLP from workloads running in the cluster.
@@ -201,6 +205,7 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
+          - metricstarttime
           - resource/gcp_project_id
           - resourcedetection
           - transform/collision

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,10 +35,10 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.122.1
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.127.0
         args:
           - "--config=/conf/collector.yaml"
-          - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"
+          - "--feature-gates=exporter.googlemanagedprometheus.intToDouble,receiver.prometheusreceiver.RemoveStartTimeAdjustment"
         ports:
           - name: otlp-grpc
             containerPort: 4317


### PR DESCRIPTION
Update the collector version to v0.127.0

Add the metricstarttime processor, and disable the prometheus adjuster to allow the metricstarttime processor to work.

Tested by adding a prometheus receiver to the metrics endpoint to scrape the GMP example app: https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed#deploy-app