### PR TITLE
Cherrypick metricstarttime

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -7,4 +7,4 @@
 # Note: The manifests in these repositories use the Google Built OpenTelemetry Collector.
 
 MANIFESTS_VERSION=0.3.0
-GBOC_VERSION=0.122.1
+GBOC_VERSION=0.127.0

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -16,9 +16,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -87,7 +87,7 @@ processors:
       operations:
       - action: add_label
         new_label: version
-        new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
 
   resourcedetection:
     detectors: [gcp]
@@ -139,9 +139,13 @@ processors:
       # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
       value: ${GOOGLE_CLOUD_PROJECT}
       action: insert
-
+  # The metricstarttime processor is important to include if you are using the prometheus receiver to ensure the start time is set properly.
+  # It is a no-op otherwise.
+  metricstarttime:
+    strategy: subtract_initial_point
 
 receivers:
+  # This collector is configured to accept OTLP metrics, logs, and traces, and is designed to receive OTLP from workloads running in the cluster.
   otlp:
     protocols:
       grpc:
@@ -178,6 +182,7 @@ service:
       processors:
       - k8sattributes
       - memory_limiter
+      - metricstarttime
       - resourcedetection
       - transform/collision
       - transform/aco-gke

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -19,9 +19,9 @@ data:
       googlecloud:
         log:
           default_log_name: opentelemetry-collector
-        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
       googlemanagedprometheus:
-        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+        user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
       # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
       # The otlp exporter could also be used to send them using OTLP grpc
       otlphttp:
@@ -90,7 +90,7 @@ data:
           operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
 
       resourcedetection:
         detectors: [gcp]
@@ -142,7 +142,6 @@ data:
           # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
           value: ${GOOGLE_CLOUD_PROJECT}
           action: insert
-
       # The metricstarttime processor is important to include if you are using the prometheus receiver to ensure the start time is set properly.
       # It is a no-op otherwise.
       metricstarttime:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -143,8 +143,13 @@ data:
           value: ${GOOGLE_CLOUD_PROJECT}
           action: insert
 
+      # The metricstarttime processor is important to include if you are using the prometheus receiver to ensure the start time is set properly.
+      # It is a no-op otherwise.
+      metricstarttime:
+        strategy: subtract_initial_point
 
     receivers:
+      # This collector is configured to accept OTLP metrics, logs, and traces, and is designed to receive OTLP from workloads running in the cluster.
       otlp:
         protocols:
           grpc:
@@ -181,6 +186,7 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
+          - metricstarttime
           - resourcedetection
           - transform/collision
           - transform/aco-gke

--- a/k8s/base/2_rbac.yaml
+++ b/k8s/base/2_rbac.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.122.1"
+    app.kubernetes.io/version: "0.127.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,7 +28,7 @@ metadata:
   namespace: opentelemetry
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.122.1"
+    app.kubernetes.io/version: "0.127.0"
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -46,7 +46,7 @@ metadata:
   name: opentelemetry-collector
   labels:
     app.kubernetes.io/name: google-built-opentelemetry-collector
-    app.kubernetes.io/version: "0.122.1"
+    app.kubernetes.io/version: "0.127.0"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -35,10 +35,10 @@ spec:
       containers:
       - name: opentelemetry-collector
         imagePullPolicy: Always
-        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.122.1
+        image: us-docker.pkg.dev/cloud-ops-agents-artifacts/google-cloud-opentelemetry-collector/otelcol-google:0.127.0
         args:
           - "--config=/conf/collector.yaml"
-          - "--feature-gates=exporter.googlemanagedprometheus.intToDouble"
+          - "--feature-gates=exporter.googlemanagedprometheus.intToDouble,receiver.prometheusreceiver.RemoveStartTimeAdjustment"
         ports:
           - name: otlp-grpc
             containerPort: 4317

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -15,9 +15,9 @@ exporters:
   googlecloud:
     log:
       default_log_name: opentelemetry-collector
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
   googlemanagedprometheus:
-    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+    user_agent: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
   # The otlphttp exporter is used to send traces to Google Cloud Trace using OTLP http/proto
   # The otlp exporter could also be used to send them using OTLP grpc
   otlphttp:
@@ -81,7 +81,7 @@ processors:
         operations:
           - action: add_label
             new_label: version
-            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.122.1 (linux/amd64)
+            new_value: Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.127.0 (linux/amd64)
   resourcedetection:
     detectors: [gcp]
     timeout: 10s
@@ -129,7 +129,12 @@ processors:
         # MAKE SURE YOU REPLACE THIS WITH YOUR PROJECT ID
         value: ${GOOGLE_CLOUD_PROJECT}
         action: insert
+  # The metricstarttime processor is important to include if you are using the prometheus receiver to ensure the start time is set properly.
+  # It is a no-op otherwise.
+  metricstarttime:
+    strategy: subtract_initial_point
 receivers:
+  # This collector is configured to accept OTLP metrics, logs, and traces, and is designed to receive OTLP from workloads running in the cluster.
   otlp:
     protocols:
       grpc:
@@ -169,6 +174,7 @@ service:
       processors:
         - k8sattributes
         - memory_limiter
+        - metricstarttime
         - resourcedetection
         - transform/collision
         - transform/aco-gke


### PR DESCRIPTION
Cherrypick of https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/pull/58 to main.

There is no reason not to use the processor with the GMP exporter, and this minimizes the diff between branches