### PR TITLE
[otlpmetric] Split unknown metric counters before computing metric start time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ generate: tools
 	cat test/fixtures/logs_input.json | $(JQ) -c > k8s/overlays/test/logs_fixture.json
 
 .PHONY: test
-test: tools
+test: tools generate
 	$(KUBECTL) kustomize k8s/overlays/test | envsubst | kubectl apply -f -
 	while : ; do \
 		$(KUBECTL) get pod/opentelemetry-collector-0 -n opentelemetry && break; \

--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -146,6 +146,18 @@ processors:
       - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
       - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
       - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
+  # For each Prometheus unknown-typed metric, which is a gauge, create a counter that is an exact copy of this metric.
+  # The GCP OTLP endpoint will add appropriate the appropriate suffixes for the counter and gauge.
+  transform/unknown-counter:
+    metric_statements:
+    - context: metric
+      statements:
+      # Copy the unknown metric, but add a suffix so we can distinguish the copy from the original.
+      - copy_metric(Concat([metric.name, "unknowncounter"], ":")) where metric.metadata["prometheus.type"] == "unknown" and not HasSuffix(metric.name, ":unknowncounter")
+      # Change the copy to a monotonic, cumulative sum.
+      - convert_gauge_to_sum("cumulative", true) where HasSuffix(metric.name, ":unknowncounter")
+      # Delete the extra suffix once we are done.
+      - set(metric.name, Substring(metric.name, 0, Len(metric.name)-Len(":unknowncounter"))) where HasSuffix(metric.name, ":unknowncounter")
 
   # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
   resource/gcp_project_id:
@@ -205,6 +217,7 @@ service:
       - resourcedetection
       - transform/collision
       - transform/aco-gke
+      - transform/unknown-counter
       - metricstarttime
       - batch
       receivers:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -149,6 +149,18 @@ data:
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
           - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
+      # For each Prometheus unknown-typed metric, which is a gauge, create a counter that is an exact copy of this metric.
+      # The GCP OTLP endpoint will add appropriate the appropriate suffixes for the counter and gauge.
+      transform/unknown-counter:
+        metric_statements:
+        - context: metric
+          statements:
+          # Copy the unknown metric, but add a suffix so we can distinguish the copy from the original.
+          - copy_metric(Concat([metric.name, "unknowncounter"], ":")) where metric.metadata["prometheus.type"] == "unknown" and not HasSuffix(metric.name, ":unknowncounter")
+          # Change the copy to a monotonic, cumulative sum.
+          - convert_gauge_to_sum("cumulative", true) where HasSuffix(metric.name, ":unknowncounter")
+          # Delete the extra suffix once we are done.
+          - set(metric.name, Substring(metric.name, 0, Len(metric.name)-Len(":unknowncounter"))) where HasSuffix(metric.name, ":unknowncounter")
 
       # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
       resource/gcp_project_id:
@@ -208,6 +220,7 @@ data:
           - resourcedetection
           - transform/collision
           - transform/aco-gke
+          - transform/unknown-counter
           - metricstarttime
           - batch
           receivers:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -142,6 +142,18 @@ processors:
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.job.name"]) where resource.attributes["k8s.job.name"] != nil
           - set(attributes["top_level_controller_type"], "CronJob") where resource.attributes["k8s.cronjob.name"] != nil
           - set(attributes["top_level_controller_name"], resource.attributes["k8s.cronjob.name"]) where resource.attributes["k8s.cronjob.name"] != nil
+  # For each Prometheus unknown-typed metric, which is a gauge, create a counter that is an exact copy of this metric.
+  # The GCP OTLP endpoint will add appropriate the appropriate suffixes for the counter and gauge.
+  transform/unknown-counter:
+    metric_statements:
+      - context: metric
+        statements:
+          # Copy the unknown metric, but add a suffix so we can distinguish the copy from the original.
+          - copy_metric(Concat([metric.name, "unknowncounter"], ":")) where metric.metadata["prometheus.type"] == "unknown" and not HasSuffix(metric.name, ":unknowncounter")
+          # Change the copy to a monotonic, cumulative sum.
+          - convert_gauge_to_sum("cumulative", true) where HasSuffix(metric.name, ":unknowncounter")
+          # Delete the extra suffix once we are done.
+          - set(metric.name, Substring(metric.name, 0, Len(metric.name)-Len(":unknowncounter"))) where HasSuffix(metric.name, ":unknowncounter")
   # When sending telemetry to the GCP OTLP endpoint, the gcp.project_id resource attribute is required to be set to your project ID.
   resource/gcp_project_id:
     attributes:
@@ -209,6 +221,7 @@ service:
         - resourcedetection
         - transform/collision
         - transform/aco-gke
+        - transform/unknown-counter
         - metricstarttime
         - batch
       receivers:

--- a/test/fixtures/metrics_expect.json
+++ b/test/fixtures/metrics_expect.json
@@ -16,6 +16,12 @@
             }
           },
           {
+            "key": "gcp.project_id",
+            "value": {
+              "stringValue": "dashpole-dev"
+            }
+          },
+          {
             "key": "cloud.provider",
             "value": {
               "stringValue": "gcp"
@@ -48,13 +54,13 @@
           {
             "key": "host.id",
             "value": {
-              "stringValue": "4288661591293009056"
+              "stringValue": "5032761239350862555"
             }
           },
           {
             "key": "host.name",
             "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-xc2n"
             }
           }
         ]
@@ -76,11 +82,173 @@
                         }
                       }
                     ],
-                    "startTimeUnixNano": "1649443416286000000",
                     "timeUnixNano": "1649443516286000000",
                     "asDouble": 3
                   }
                 ]
+              },
+              "metadata": [
+                {
+                  "key": "prometheus.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "metrics_input.json"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "fake_untyped_metric",
+              "sum": {
+                "aggregationTemporality": 2,
+                "isMonotonic": true
+              },
+              "metadata": [
+                {
+                  "key": "prometheus.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "metrics_input.json"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "demo"
+            }
+          },
+          {
+            "key": "service.instance.id",
+            "value": {
+              "stringValue": "10.92.5.2:15692"
+            }
+          },
+          {
+            "key": "gcp.project_id",
+            "value": {
+              "stringValue": "dashpole-dev"
+            }
+          },
+          {
+            "key": "cloud.provider",
+            "value": {
+              "stringValue": "gcp"
+            }
+          },
+          {
+            "key": "cloud.account.id",
+            "value": {
+              "stringValue": "dashpole-dev"
+            }
+          },
+          {
+            "key": "cloud.platform",
+            "value": {
+              "stringValue": "gcp_kubernetes_engine"
+            }
+          },
+          {
+            "key": "cloud.region",
+            "value": {
+              "stringValue": "us-east1"
+            }
+          },
+          {
+            "key": "k8s.cluster.name",
+            "value": {
+              "stringValue": "otlp-test-2"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "5032761239350862555"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-xc2n"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "fake_untyped_metric",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "ex_com_lemons_untyped",
+                        "value": {
+                          "stringValue": "13"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1649443517286000000",
+                    "asDouble": 10
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "prometheus.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "metrics_input.json"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "fake_untyped_metric",
+              "sum": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "ex_com_lemons_untyped",
+                        "value": {
+                          "stringValue": "13"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1649443517286000000",
+                    "asDouble": 7
+                  }
+                ],
+                "aggregationTemporality": 2,
+                "isMonotonic": true
               },
               "metadata": [
                 {

--- a/test/fixtures/metrics_input.json
+++ b/test/fixtures/metrics_input.json
@@ -34,9 +34,64 @@
                                     }
                                  }
                               ],
-                              "startTimeUnixNano": "1649443416286000000",
                               "timeUnixNano": "1649443516286000000",
                               "asDouble": 3
+                           }
+                        ]
+                     },
+                     "metadata": [
+                        {
+                           "key": "prometheus.type",
+                           "value": {
+                              "stringValue": "unknown"
+                           }
+                        }
+                     ]
+                  }
+               ]
+            }
+         ]
+      }
+   ]
+}
+{
+   "resourceMetrics": [
+      {
+         "resource": {
+            "attributes": [
+               {
+                  "key": "service.name",
+                  "value": {
+                     "stringValue": "demo"
+                  }
+               },
+               {
+                  "key": "service.instance.id",
+                  "value": {
+                     "stringValue": "10.92.5.2:15692"
+                  }
+               }
+            ]
+         },
+         "scopeMetrics": [
+            {
+               "scope": {},
+               "metrics": [
+                  {
+                     "name": "fake_untyped_metric",
+                     "gauge": {
+                        "dataPoints": [
+                           {
+                              "attributes": [
+                                 {
+                                    "key": "ex_com_lemons_untyped",
+                                    "value": {
+                                       "stringValue": "13"
+                                    }
+                                 }
+                              ],
+                              "timeUnixNano": "1649443517286000000",
+                              "asDouble": 10
                            }
                         ]
                      },

--- a/test/verify.bats
+++ b/test/verify.bats
@@ -15,17 +15,17 @@ assert_equal() {
 }
 
 @test "spans contain host.name resource attribute" {
-      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
+      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[0].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "spans contain cloud.provider resource attribute" {
-      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
+      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
       assert_equal "$result" "true"
 }
 
 @test "spans contain cloud.account.id resource attribute" {
-      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
+      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
       assert_equal "$result" "true"
 }
 
@@ -35,101 +35,101 @@ assert_equal() {
 }
 
 @test "spans contain cloud.region resource attribute" {
-      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
+      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
       assert_equal "$result" "true"
 }
 
 @test "spans contain k8s.cluster.name resource attribute" {
-      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
+      result=$(cat test/fixtures/spans_expect.json | .tools/jq ".resourceSpans[0].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain host.name resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain cloud.provider resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain cloud.account.id resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain cloud.platform resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain cloud.region resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
       assert_equal "$result" "true"
 }
 
 @test "logs contain k8s.cluster.name resource attribute" {
-      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
+      result=$(cat test/fixtures/logs_expect.json | .tools/jq ".resourceLogs[0].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain host.name resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain cloud.provider resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain cloud.account.id resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain cloud.platform resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain cloud.region resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
       assert_equal "$result" "true"
 }
 
 @test "metrics contain k8s.cluster.name resource attribute" {
-      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
+      result=$(cat test/fixtures/metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain host.name resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"host.name\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain cloud.provider resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.provider\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain cloud.account.id resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.account.id\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain cloud.platform resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.platform\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain cloud.region resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"cloud.region\") != null")
       assert_equal "$result" "true"
 }
 
 @test "self metrics contain k8s.cluster.name resource attribute" {
-      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
+      result=$(cat test/fixtures/self_metrics_expect.json | .tools/jq ".resourceMetrics[0].resource.attributes[]?" | .tools/jq "select(.key == \"k8s.cluster.name\") != null")
       assert_equal "$result" "true"
 }


### PR DESCRIPTION
This would change:

```
name: my_metric, type: gauge, metadata[prometheus.type]: "unknown"
```
into
```
name: my_metric, type: gauge, metadata[prometheus.type]: "unknown"
name: my_metric, type: counter, metadata[prometheus.type]: "unknown", monotonic: true, temporality: cumulative
```

Note that the names would be duplicated, so the OTLP endpoint will need to add different suffixes to the metric in order to prevent errors writing to cloud monitoring.