### PR TITLE
Remove replicas from deployment

### DIFF
--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -227,6 +227,5 @@ data:
                   endpoint: ${env:MY_POD_IP}:14317
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   name: collector-config
   namespace: opentelemetry

--- a/k8s/base/4_deployment.yaml
+++ b/k8s/base/4_deployment.yaml
@@ -20,7 +20,6 @@ metadata:
   labels:
     app: opentelemetry-collector
 spec:
-  replicas: 2
   selector:
     matchLabels:
       app: opentelemetry-collector


### PR DESCRIPTION
Remove replicas from deployment spec.

For context: I'm running this deployment managed by fluxcd: https://fluxcd.io/

When using fluxcd, every time a reconciliation occurs the replicas will be reapplied. This causes a lot of flapping between the HPA desired replica count and the replica count defined here.