### PR TITLE
Updating the collector config to use otlphttp exporter

### DIFF
--- a/config/collector.yaml
+++ b/config/collector.yaml
@@ -178,10 +178,11 @@ service:
       - otlp
     metrics/otlp:
       exporters:
-      - googlemanagedprometheus
+      - otlphttp
       processors:
       - k8sattributes
       - memory_limiter
+      - resource/gcp_project_id
       - metricstarttime
       - resourcedetection
       - transform/collision
@@ -191,12 +192,14 @@ service:
       - otlp
     metrics/self-metrics:
       exporters:
-      - googlemanagedprometheus
+      - otlphttp
       processors:
       - filter/self-metrics
       - metricstransform/self-metrics
       - k8sattributes
       - memory_limiter
+      - resource/gcp_project_id
+      - metricstarttime
       - resourcedetection
       - batch
       receivers:

--- a/k8s/base/1_configmap.yaml
+++ b/k8s/base/1_configmap.yaml
@@ -181,10 +181,11 @@ data:
           - otlp
         metrics/otlp:
           exporters:
-          - googlemanagedprometheus
+          - otlphttp
           processors:
           - k8sattributes
           - memory_limiter
+          - resource/gcp_project_id
           - metricstarttime
           - resourcedetection
           - transform/collision
@@ -194,12 +195,14 @@ data:
           - otlp
         metrics/self-metrics:
           exporters:
-          - googlemanagedprometheus
+          - otlphttp
           processors:
           - filter/self-metrics
           - metricstransform/self-metrics
           - k8sattributes
           - memory_limiter
+          - resource/gcp_project_id
+          - metricstarttime
           - resourcedetection
           - batch
           receivers:

--- a/k8s/overlays/test/collector.yaml
+++ b/k8s/overlays/test/collector.yaml
@@ -188,6 +188,7 @@ service:
       processors:
         - k8sattributes
         - memory_limiter
+        - resource/gcp_project_id
         - metricstarttime
         - resourcedetection
         - transform/collision
@@ -203,6 +204,8 @@ service:
         - metricstransform/self-metrics
         - k8sattributes
         - memory_limiter
+        - resource/gcp_project_id
+        - metricstarttime
         - resourcedetection
         - batch
       receivers:

--- a/test/fixtures/logs_expect.json
+++ b/test/fixtures/logs_expect.json
@@ -12,7 +12,7 @@
           {
             "key": "cloud.account.id",
             "value": {
-              "stringValue": "dashpole-dev"
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -24,35 +24,38 @@
           {
             "key": "cloud.region",
             "value": {
-              "stringValue": "us-east1"
+              "stringValue": "us-central1"
             }
           },
           {
             "key": "k8s.cluster.name",
             "value": {
-              "stringValue": "otlp-test-2"
+              "stringValue": "cluster-2"
             }
           },
           {
             "key": "host.id",
             "value": {
-              "stringValue": "4288661591293009056"
+              "stringValue": "5376163897820546005"
             }
           },
           {
             "key": "host.name",
             "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "gke-cluster-2-default-pool-3e11d9c0-wj2z"
             }
           }
         ]
       },
+      "schemaUrl": "https://opentelemetry.io/schemas/1.6.1",
       "scopeLogs": [
         {
           "scope": {},
           "logRecords": [
             {
               "timeUnixNano": "1655923556339005014",
+              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
+              "spanId": "d39ba683befbd246",
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -105,12 +108,13 @@
                     "stringValue": "logs_input.json"
                   }
                 }
-              ],
-              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
-              "spanId": "d39ba683befbd246"
+              ]
             },
             {
               "timeUnixNano": "1655923556339179012",
+              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
+              "spanId": "97c0f2f642dd1306",
+              "flags": 1,
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -163,13 +167,12 @@
                     "stringValue": "logs_input.json"
                   }
                 }
-              ],
-              "flags": 1,
-              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
-              "spanId": "97c0f2f642dd1306"
+              ]
             },
             {
               "timeUnixNano": "1655923556339195932",
+              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
+              "spanId": "fded437fb39abed9",
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -222,12 +225,12 @@
                     "stringValue": "logs_input.json"
                   }
                 }
-              ],
-              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
-              "spanId": "fded437fb39abed9"
+              ]
             },
             {
               "timeUnixNano": "1655923556339234508",
+              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
+              "spanId": "6acb5055846322e7",
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -286,12 +289,12 @@
                     "stringValue": "logs_input.json"
                   }
                 }
-              ],
-              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
-              "spanId": "6acb5055846322e7"
+              ]
             },
             {
               "timeUnixNano": "1655923556339240397",
+              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
+              "spanId": "d9ae3a7b26ef239f",
               "body": {
                 "kvlistValue": {
                   "values": [
@@ -350,14 +353,11 @@
                     "stringValue": "logs_input.json"
                   }
                 }
-              ],
-              "traceId": "ad57e7b40d6f172d04f8a0e1b80cafe4",
-              "spanId": "d9ae3a7b26ef239f"
+              ]
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+      ]
     }
   ]
 }

--- a/test/fixtures/metrics_expect.json
+++ b/test/fixtures/metrics_expect.json
@@ -16,6 +16,12 @@
             }
           },
           {
+            "key": "gcp.project_id",
+            "value": {
+              "stringValue": "westphalrafael-dev"
+            }
+          },
+          {
             "key": "cloud.provider",
             "value": {
               "stringValue": "gcp"
@@ -24,7 +30,7 @@
           {
             "key": "cloud.account.id",
             "value": {
-              "stringValue": "dashpole-dev"
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -36,35 +42,50 @@
           {
             "key": "cloud.region",
             "value": {
-              "stringValue": "us-east1"
+              "stringValue": "us-central1"
             }
           },
           {
             "key": "k8s.cluster.name",
             "value": {
-              "stringValue": "otlp-test-2"
+              "stringValue": "cluster-2"
             }
           },
           {
             "key": "host.id",
             "value": {
-              "stringValue": "4288661591293009056"
+              "stringValue": "5376163897820546005"
             }
           },
           {
             "key": "host.name",
             "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "gke-cluster-2-default-pool-3e11d9c0-wj2z"
             }
           }
         ]
       },
+      "schemaUrl": "https://opentelemetry.io/schemas/1.6.1",
       "scopeMetrics": [
         {
           "scope": {},
           "metrics": [
             {
               "name": "fake_untyped_metric",
+              "metadata": [
+                {
+                  "key": "prometheus.type",
+                  "value": {
+                    "stringValue": "unknown"
+                  }
+                },
+                {
+                  "key": "log.file.name",
+                  "value": {
+                    "stringValue": "metrics_input.json"
+                  }
+                }
+              ],
               "gauge": {
                 "dataPoints": [
                   {
@@ -81,26 +102,11 @@
                     "asDouble": 3
                   }
                 ]
-              },
-              "metadata": [
-                {
-                  "key": "prometheus.type",
-                  "value": {
-                    "stringValue": "unknown"
-                  }
-                },
-                {
-                  "key": "log.file.name",
-                  "value": {
-                    "stringValue": "metrics_input.json"
-                  }
-                }
-              ]
+              }
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.6.1"
+      ]
     }
   ]
 }

--- a/test/fixtures/self_metrics_expect.json
+++ b/test/fixtures/self_metrics_expect.json
@@ -6,7 +6,7 @@
           {
             "key": "service.instance.id",
             "value": {
-              "stringValue": "5b6865f5-4b90-4481-96d2-21b04af5a664"
+              "stringValue": "886a2747-47b7-4c15-accc-7f792099173a"
             }
           },
           {
@@ -18,19 +18,13 @@
           {
             "key": "service.version",
             "value": {
-              "stringValue": "0.128.0"
+              "stringValue": "0.131.0"
             }
           },
           {
             "key": "k8s.pod.ip",
             "value": {
-              "stringValue": "10.106.129.156"
-            }
-          },
-          {
-            "key": "k8s.node.name",
-            "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "10.48.8.5"
             }
           },
           {
@@ -48,19 +42,31 @@
           {
             "key": "k8s.pod.start_time",
             "value": {
-              "stringValue": "2025-06-13T20:31:11Z"
+              "stringValue": "2026-01-22T18:56:32Z"
             }
           },
           {
             "key": "k8s.pod.uid",
             "value": {
-              "stringValue": "9f4bd3c0-adca-4aab-ac02-6c0a418f986c"
+              "stringValue": "9d2ba2cc-9853-4bb1-98ea-7e640ade8497"
             }
           },
           {
             "key": "k8s.statefulset.name",
             "value": {
               "stringValue": "opentelemetry-collector"
+            }
+          },
+          {
+            "key": "k8s.node.name",
+            "value": {
+              "stringValue": "gke-cluster-2-default-pool-3e11d9c0-wj2z"
+            }
+          },
+          {
+            "key": "gcp.project_id",
+            "value": {
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -72,7 +78,7 @@
           {
             "key": "cloud.account.id",
             "value": {
-              "stringValue": "dashpole-dev"
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -84,29 +90,30 @@
           {
             "key": "cloud.region",
             "value": {
-              "stringValue": "us-east1"
+              "stringValue": "us-central1"
             }
           },
           {
             "key": "k8s.cluster.name",
             "value": {
-              "stringValue": "otlp-test-2"
+              "stringValue": "cluster-2"
             }
           },
           {
             "key": "host.id",
             "value": {
-              "stringValue": "4288661591293009056"
+              "stringValue": "5376163897820546005"
             }
           },
           {
             "key": "host.name",
             "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "gke-cluster-2-default-pool-3e11d9c0-wj2z"
             }
           }
         ]
       },
+      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0",
       "scopeMetrics": [
         {
           "scope": {
@@ -120,9 +127,9 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "startTimeUnixNano": "1749846676123345013",
-                    "timeUnixNano": "1749846736121952077",
-                    "asInt": "118149120"
+                    "startTimeUnixNano": "1769108425898008790",
+                    "timeUnixNano": "1769108485897919734",
+                    "asInt": "126828544"
                   }
                 ]
               }
@@ -132,29 +139,28 @@
               "description": "Uptime of the process [alpha]",
               "unit": "s",
               "sum": {
+                "aggregationTemporality": 2,
+                "isMonotonic": true,
                 "dataPoints": [
                   {
                     "attributes": [
                       {
                         "key": "version",
                         "value": {
-                          "stringValue": "Google-Cloud-OTLP manifests:0.3.0 OpenTelemetry Collector Built By Google/0.128.0 (linux/amd64)"
+                          "stringValue": "Google-Cloud-OTLP manifests:0.5.0 OpenTelemetry Collector Built By Google/0.131.0 (linux/amd64)"
                         }
                       }
                     ],
-                    "startTimeUnixNano": "1749846676123400604",
-                    "timeUnixNano": "1749846736121958248",
-                    "asDouble": 59.967476818
+                    "startTimeUnixNano": "1769108425898053083",
+                    "timeUnixNano": "1769108485897928603",
+                    "asDouble": 59.981468816
                   }
-                ],
-                "aggregationTemporality": 2,
-                "isMonotonic": true
+                ]
               }
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.26.0"
+      ]
     }
   ]
 }

--- a/test/fixtures/spans_expect.json
+++ b/test/fixtures/spans_expect.json
@@ -90,7 +90,7 @@
           {
             "key": "gcp.project_id",
             "value": {
-              "stringValue": "dashpole-dev"
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -102,7 +102,7 @@
           {
             "key": "cloud.account.id",
             "value": {
-              "stringValue": "dashpole-dev"
+              "stringValue": "westphalrafael-dev"
             }
           },
           {
@@ -114,29 +114,30 @@
           {
             "key": "cloud.region",
             "value": {
-              "stringValue": "us-east1"
+              "stringValue": "us-central1"
             }
           },
           {
             "key": "k8s.cluster.name",
             "value": {
-              "stringValue": "otlp-test-2"
+              "stringValue": "cluster-2"
             }
           },
           {
             "key": "host.id",
             "value": {
-              "stringValue": "4288661591293009056"
+              "stringValue": "5376163897820546005"
             }
           },
           {
             "key": "host.name",
             "value": {
-              "stringValue": "gk3-otlp-test-2-nap-11zfxnfd-edd3704c-msgx"
+              "stringValue": "gke-cluster-2-default-pool-3e11d9c0-wj2z"
             }
           }
         ]
       },
+      "schemaUrl": "https://opentelemetry.io/schemas/1.10.0",
       "scopeSpans": [
         {
           "scope": {
@@ -266,8 +267,7 @@
             }
           ]
         }
-      ],
-      "schemaUrl": "https://opentelemetry.io/schemas/1.10.0"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This change updates the collector configuration to use the otlphttp exporter for metrics, instead of the current googlemanagedprometheus.

This change requires us to have a gcp.project_id label.
Additionally, I added the metricstarttime processor to the pipeline that didn't have it, since this was done previously by the GMP exporter.

I deployed this in my cluster and verified that the self-metrics and the prometheus.googleaplis.com/gen/gauge metrics are present.